### PR TITLE
fix: delete latex formula to display image correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@
 
       Fig 1. The illustration of the proposed framework. The middle section depicts the internal interactions (**light gray line**) and external interactions (**dark gray line**) in Hi-Core. Internally, the CRL agent is structured in two layers: the high-level policy formulation (**orange**) and the low-level policy learning (**green**). Furthermore, the policy library (**blue**) is constructed to store and retrieve policies. The three surrounding boxes illustrate their internal workflow when the agent encounters new tasks.
 
-    - Method Overview: The high level LLM is used to generate a series of goals $\{g_i\}$ . The low level is a RL with goal-directed, it need to generate a policy $\pi$ in response to the goals. Policy library is used to store successful policy. When encountering new tasks, the library can retrieve relevant experience to assist high and low level policy agent.
+    - Method Overview: The high level LLM is used to generate a series of goals g_i . The low level is a RL with goal-directed, it needs to generate a policy in response to the goals. Policy library is used to store successful policy. When encountering new tasks, the library can retrieve relevant experience to assist high and low level policy agent.
 
 ***
 


### PR DESCRIPTION
fix the bug when displaying "hi core.png", due to the latex in the text. 